### PR TITLE
Bug Fix: Fixed Unclosed File Descriptor in Read_annotation

### DIFF
--- a/N-dataset functions/Read_annotation.m
+++ b/N-dataset functions/Read_annotation.m
@@ -19,3 +19,5 @@ rows = fread(FID, 1, 'int16');
 cols = fread(FID, 1, 'int16');
 obj_contour = fread(FID, rows*cols, 'int16');
 obj_contour = reshape(obj_contour, [rows, cols]);
+
+fclose(FID);


### PR DESCRIPTION
Issue: When doing batch scripting to extractROI in N-CALTECH dataset, script was unable to open the next file as there were too many files concurrently opened by the process. 

Fix: Added fclose(FID) in Read_annotation to release file descriptor before function returns . 
